### PR TITLE
[feat/#1-oauth2-login]: 유저 정보 DB 저장하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ repositories {
 
 dependencies {
 	//ORM
-	//implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	//runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	//Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/wondrous/oauth2_JWT/entity/OAuth2JwtMember.java
+++ b/src/main/java/com/wondrous/oauth2_JWT/entity/OAuth2JwtMember.java
@@ -1,0 +1,44 @@
+package com.wondrous.oauth2_JWT.entity;
+
+import com.wondrous.oauth2_JWT.dto.UserDto;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class OAuth2JwtMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String name;
+
+    private String email;
+
+    private String role;
+
+    public static OAuth2JwtMember newMember(UserDto userDto) {
+        return builder()
+                .name(userDto.getName())
+                .username(userDto.getUsername())
+                .role(userDto.getRole()).build();
+    }
+
+    public void updateMember(UserDto userDto) {
+        this.name = userDto.getName();
+        this.username = userDto.getUsername();
+        this.role = userDto.getRole();
+    }
+
+
+}

--- a/src/main/java/com/wondrous/oauth2_JWT/repository/MemberRepository.java
+++ b/src/main/java/com/wondrous/oauth2_JWT/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.wondrous.oauth2_JWT.repository;
+
+import com.wondrous.oauth2_JWT.entity.OAuth2JwtMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<OAuth2JwtMember, Long> {
+    OAuth2JwtMember findByUsername(String username);
+}

--- a/src/main/java/com/wondrous/oauth2_JWT/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/wondrous/oauth2_JWT/service/CustomOAuth2UserService.java
@@ -1,6 +1,9 @@
 package com.wondrous.oauth2_JWT.service;
 
 import com.wondrous.oauth2_JWT.dto.*;
+import com.wondrous.oauth2_JWT.entity.OAuth2JwtMember;
+import com.wondrous.oauth2_JWT.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -10,11 +13,17 @@ import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+@RequiredArgsConstructor
+
 @Service
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
+    private final MemberRepository memberRepository;
+
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        // 1. 인가 서버 ㅇ
 
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
@@ -46,14 +55,29 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             throw new OAuth2AuthenticationException(new OAuth2Error("invalid_social_account", "잘못된 소셜 계정입니다.", null));
         }
 
-        // 우리 서버에서 담을 User Dto
+        // 이미 가입된 유저인지 확인 후 가입 or 로그인 처리
+
         //이름이 겹칠 상황을 대비하여 이름 + 리소스 서버 Id로 usernmae 생성
         String username = oAuth2User.getName() + " " + oAuth2Response.getProviderId();
+        OAuth2JwtMember existMember = memberRepository.findByUsername(username);
+
 
         UserDto userDto = new UserDto(
                 "ROLE_USER",
                 oAuth2Response.getName(),
                 username);
+
+        if (existMember == null) {
+            System.out.println("새 유저 회원 가입 중");
+            OAuth2JwtMember newMember  = OAuth2JwtMember.newMember(userDto);
+            memberRepository.save(newMember);
+
+        }
+        else {
+            System.out.println("인가 서버로부터 기존 유저 정보 업데이트 중");
+            existMember.updateMember(userDto);
+            memberRepository.save(existMember);
+        }
 
         return new CustomOAuth2User(userDto);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,9 +6,38 @@ spring:
   application:
     name: OAuth2 JWT Hands On
 
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
+    properties:
+      hibernate:
+        #dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true
+        highlight_sql: true
+        use_sql_comments: true
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/oauth2_jwt?useSSL=false&useUnicode=true&character_set_server=utf8mb4&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true
+    username: root
+    password: "0000"
+
 server:
   servlet:
     encoding:
       charset: UTF-8
       force-response: 'true'
+
+
+logging:
+  level:
+    root: info
+    org.hibernate.sql: debug
+    org.hibernate.type.descriptor.sql: debug
+    org.springframework.security: trace
+
+
 


### PR DESCRIPTION
 # ✒️ 관련 이슈번호
- https://github.com/kimgt0128/security-6-oauth2-JWT-honds-on-Spring-boot-3/issues/1
  
  


# 🔑 Key Changes
- 의존성 추가
- 유저 존재 확인, 로그인 또는 가입 로직 구현


# 📢 After To-do
- [ ] SecurityFilter에서 CustomOAuth2UserService 방식과 직접 MVC로 구현하는 방식의 효율성 비교해 보기
- [ ] 서버 자체에서 유저를 관리하는 JWT 로직 구현