### PR TITLE
[feat/#4-jwt]: Refresh Token Rotate 방식으로 Access 토큰 재발급 구현

### DIFF
--- a/src/main/java/com/wondrous/oauth2_JWT/config/SecurityConfig.java
+++ b/src/main/java/com/wondrous/oauth2_JWT/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.wondrous.oauth2_JWT.config;
 
 import com.wondrous.oauth2_JWT.jwt.filter.JWTFilter;
 import com.wondrous.oauth2_JWT.jwt.service.JWTUtil;
+import com.wondrous.oauth2_JWT.oauth2.CustomFailureHandler;
 import com.wondrous.oauth2_JWT.oauth2.CustomSuccessHandler;
 import com.wondrous.oauth2_JWT.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomSuccessHandler customSuccessHandler;
+    private final CustomFailureHandler customFailureHandler;
     private final JWTUtil jwtUtil;
 
     @Bean
@@ -40,7 +42,8 @@ public class SecurityConfig {
                 .oauth2Login((oauth2) -> oauth2
                         .userInfoEndpoint((userInfoEndpointConfig -> userInfoEndpointConfig
                                 .userService(customOAuth2UserService)))
-                        .successHandler(customSuccessHandler));
+                        .successHandler(customSuccessHandler)
+                        .failureHandler(customFailureHandler));
 
         http
                 .addFilterBefore(new JWTFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/wondrous/oauth2_JWT/config/SecurityConfig.java
+++ b/src/main/java/com/wondrous/oauth2_JWT/config/SecurityConfig.java
@@ -1,8 +1,8 @@
 package com.wondrous.oauth2_JWT.config;
 
 
-import com.wondrous.oauth2_JWT.jwt.filter.JWTFilter;
-import com.wondrous.oauth2_JWT.jwt.service.JWTUtil;
+import com.wondrous.oauth2_JWT.jwt.filter.JwtAuthenticationFilter;
+import com.wondrous.oauth2_JWT.jwt.service.JwtTokenProvider;
 import com.wondrous.oauth2_JWT.oauth2.CustomFailureHandler;
 import com.wondrous.oauth2_JWT.oauth2.CustomSuccessHandler;
 import com.wondrous.oauth2_JWT.service.CustomOAuth2UserService;
@@ -25,7 +25,7 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomSuccessHandler customSuccessHandler;
     private final CustomFailureHandler customFailureHandler;
-    private final JWTUtil jwtUtil;
+    private final JwtTokenProvider jwtUtil;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, CustomOAuth2UserService customOAuth2UserService) throws Exception{
@@ -46,7 +46,7 @@ public class SecurityConfig {
                         .failureHandler(customFailureHandler));
 
         http
-                .addFilterBefore(new JWTFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
         // 경로별 인가
         http

--- a/src/main/java/com/wondrous/oauth2_JWT/jwt/controller/ReissuController.java
+++ b/src/main/java/com/wondrous/oauth2_JWT/jwt/controller/ReissuController.java
@@ -1,0 +1,31 @@
+package com.wondrous.oauth2_JWT.jwt.controller;
+
+import com.wondrous.oauth2_JWT.jwt.service.JwtTokenProvider;
+import com.wondrous.oauth2_JWT.jwt.service.JwtTokenReissueService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+
+@RestController
+public class ReissuController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtTokenReissueService jwtTokenReissueService;
+
+    @PostMapping("/reissue")
+    public String reissue(@CookieValue(name = "refresh") String refreshToken,
+                          HttpServletResponse response) {
+        System.out.println("reissu controller, refresh token: " + refreshToken);
+
+        String newAccessToken =  jwtTokenReissueService.reissue(refreshToken);
+
+        response.setStatus(HttpServletResponse.SC_OK);
+
+        return newAccessToken;
+    }
+}

--- a/src/main/java/com/wondrous/oauth2_JWT/jwt/controller/ReissuController.java
+++ b/src/main/java/com/wondrous/oauth2_JWT/jwt/controller/ReissuController.java
@@ -1,7 +1,9 @@
 package com.wondrous.oauth2_JWT.jwt.controller;
 
+import com.wondrous.oauth2_JWT.jwt.dto.ReissueTokenResponse;
 import com.wondrous.oauth2_JWT.jwt.service.JwtTokenProvider;
 import com.wondrous.oauth2_JWT.jwt.service.JwtTokenReissueService;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -22,10 +24,21 @@ public class ReissuController {
                           HttpServletResponse response) {
         System.out.println("reissu controller, refresh token: " + refreshToken);
 
-        String newAccessToken =  jwtTokenReissueService.reissue(refreshToken);
+        ReissueTokenResponse  reissueToken=  jwtTokenReissueService.reissue(refreshToken);
+
+        String newAccessToken = reissueToken.getAccessToken();
+        String newRefreshToken = reissueToken.getRefreshToken();
 
         response.setStatus(HttpServletResponse.SC_OK);
+        response.setHeader("access", newAccessToken);
+        response.addCookie(createCookie("refresh", newRefreshToken));
 
         return newAccessToken;
+    }
+
+    private Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setHttpOnly(true);
+        return cookie;
     }
 }

--- a/src/main/java/com/wondrous/oauth2_JWT/jwt/dto/ReissueTokenResponse.java
+++ b/src/main/java/com/wondrous/oauth2_JWT/jwt/dto/ReissueTokenResponse.java
@@ -1,0 +1,13 @@
+package com.wondrous.oauth2_JWT.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ReissueTokenResponse {
+
+    private String refreshToken;
+    private String accessToken;
+
+}

--- a/src/main/java/com/wondrous/oauth2_JWT/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wondrous/oauth2_JWT/jwt/filter/JwtAuthenticationFilter.java
@@ -3,14 +3,13 @@ package com.wondrous.oauth2_JWT.jwt.filter;
 
 import com.wondrous.oauth2_JWT.dto.CustomOAuth2User;
 import com.wondrous.oauth2_JWT.dto.UserDto;
-import com.wondrous.oauth2_JWT.jwt.service.JWTUtil;
+import com.wondrous.oauth2_JWT.jwt.service.JwtTokenProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.apache.tomcat.util.http.parser.Authorization;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -21,9 +20,9 @@ import java.io.IOException;
 @RequiredArgsConstructor
 
 //필터는 한 번만 요청되면 되므로 OncePerRequestFIlter 상속
-public class JWTFilter extends OncePerRequestFilter {
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-     private final JWTUtil jwtUtil;
+     private final JwtTokenProvider jwtUtil;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {

--- a/src/main/java/com/wondrous/oauth2_JWT/jwt/service/JWTUtil.java
+++ b/src/main/java/com/wondrous/oauth2_JWT/jwt/service/JWTUtil.java
@@ -20,6 +20,11 @@ public class JWTUtil {
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 
+    // access or refresh 토큰 확인을 위한 카테고리 Getter
+    public String getCategory(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
+    }
+
     public String getUsername(String token) {
 
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
@@ -35,9 +40,10 @@ public class JWTUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
-    public String createJwt(String username, String role, Long expiredMs) {
+    public String createJwt(String category, String username, String role, Long expiredMs) {
 
         return Jwts.builder()
+                .claim("category", category)
                 .claim("username", username)
                 .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))

--- a/src/main/java/com/wondrous/oauth2_JWT/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/com/wondrous/oauth2_JWT/jwt/service/JwtTokenProvider.java
@@ -10,11 +10,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 @Component
-public class JWTUtil {
+public class JwtTokenProvider {
 
     private SecretKey secretKey;
 
-    public JWTUtil(@Value("${jwt.secret}")String secret) {
+    public JwtTokenProvider(@Value("${jwt.secret}")String secret) {
 
 
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());

--- a/src/main/java/com/wondrous/oauth2_JWT/jwt/service/JwtTokenReissueService.java
+++ b/src/main/java/com/wondrous/oauth2_JWT/jwt/service/JwtTokenReissueService.java
@@ -1,0 +1,45 @@
+package com.wondrous.oauth2_JWT.jwt.service;
+
+import com.wondrous.oauth2_JWT.jwt.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+
+@Service
+public class JwtTokenReissueService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public String reissue(String refreshToken) {
+        System.out.println("refreshToken: " + refreshToken);
+
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            throw new IllegalArgumentException("Refresh token cannot be null or empty");
+            //이후 Exception Handler로 대체
+        }
+
+        if (jwtTokenProvider.isExpired(refreshToken)) {
+            throw new IllegalArgumentException("Refresh token is expired");
+        }
+
+        String category = jwtTokenProvider.getCategory(refreshToken);
+        System.out.println("category: " + category);
+        if (!category.equals("refresh")) {
+            throw new IllegalArgumentException("Refresh token does not match expected category");
+        }
+
+        String username = jwtTokenProvider.getUsername(refreshToken);
+        String role = jwtTokenProvider.getRole(refreshToken);
+
+        System.out.println("reissued token created");
+        String newAccessToken = jwtTokenProvider.createJwt("access", username, role,  600000L);
+
+        return newAccessToken;
+
+    }
+
+
+
+
+}

--- a/src/main/java/com/wondrous/oauth2_JWT/jwt/service/JwtTokenReissueService.java
+++ b/src/main/java/com/wondrous/oauth2_JWT/jwt/service/JwtTokenReissueService.java
@@ -1,5 +1,6 @@
 package com.wondrous.oauth2_JWT.jwt.service;
 
+import com.wondrous.oauth2_JWT.jwt.dto.ReissueTokenResponse;
 import com.wondrous.oauth2_JWT.jwt.filter.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,7 +12,7 @@ public class JwtTokenReissueService {
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    public String reissue(String refreshToken) {
+    public ReissueTokenResponse reissue(String refreshToken) {
         System.out.println("refreshToken: " + refreshToken);
 
         if (refreshToken == null || refreshToken.isEmpty()) {
@@ -32,10 +33,12 @@ public class JwtTokenReissueService {
         String username = jwtTokenProvider.getUsername(refreshToken);
         String role = jwtTokenProvider.getRole(refreshToken);
 
+        // RTR(Refresh Token Rotate) 방식 적용
         System.out.println("reissued token created");
         String newAccessToken = jwtTokenProvider.createJwt("access", username, role,  600000L);
+        String newRefreshToken = jwtTokenProvider.createJwt("refresh", username, role, 86400000L);
 
-        return newAccessToken;
+        return new ReissueTokenResponse(newRefreshToken, newAccessToken);
 
     }
 

--- a/src/main/java/com/wondrous/oauth2_JWT/oauth2/CustomFailureHandler.java
+++ b/src/main/java/com/wondrous/oauth2_JWT/oauth2/CustomFailureHandler.java
@@ -1,0 +1,21 @@
+package com.wondrous.oauth2_JWT.oauth2;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+
+@Component
+public class CustomFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.sendRedirect("http//localhost:3000/"); //프론트측과 약속한 에러 페이지로 이동시키기
+    }
+}

--- a/src/main/java/com/wondrous/oauth2_JWT/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/com/wondrous/oauth2_JWT/oauth2/CustomSuccessHandler.java
@@ -7,7 +7,9 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -23,6 +25,9 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private final JWTUtil jwtUtil;
 
+
+
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
 
@@ -36,14 +41,24 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         GrantedAuthority auth = authoritiesIterator.next();
         String role = auth.getAuthority();
 
-        String token = jwtUtil.createJwt(username, role, 60*60*60L);
+        // 토큰 생성
+        String access = jwtUtil.createJwt("access", username, role, 60*60*60L);
+        String refresh = jwtUtil.createJwt("refresh", username, role, 86400000L);
 
-        response.addCookie(createCookie("Authorization", token));
+
+
+        // 토큰 저장 - 이후 구현
+
+        // 응답 설정
+        response.setStatus(HttpStatus.OK.value());
+        response.setHeader("access", access);
+        response.addCookie(createCookie("access", access));
         response.sendRedirect("http//localhost:3000/");
 
 
     }
 
+    // 이후 모듈화
     private Cookie createCookie(String key, String value) {
         Cookie cookie = new Cookie(key, value);
         //cookie.setSecure(true); - https에서만 허용하도록(실제 배포시)

--- a/src/main/java/com/wondrous/oauth2_JWT/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/com/wondrous/oauth2_JWT/oauth2/CustomSuccessHandler.java
@@ -1,7 +1,7 @@
 package com.wondrous.oauth2_JWT.oauth2;
 
 import com.wondrous.oauth2_JWT.dto.CustomOAuth2User;
-import com.wondrous.oauth2_JWT.jwt.service.JWTUtil;
+import com.wondrous.oauth2_JWT.jwt.service.JwtTokenProvider;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,7 +9,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -23,7 +22,7 @@ import java.util.Iterator;
 @Component
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final JWTUtil jwtUtil;
+    private final JwtTokenProvider jwtUtil;
 
 
 


### PR DESCRIPTION
 # ✒️ 관련 이슈번호
- https://github.com/kimgt0128/security-6-oauth2-JWT-hands-on-Spring-boot-3/issues/4
  
  


# 🔑 Key Changes
- 로그인 실패 핸들러 추가
- 리프레시로 엑세스 재발급
- RTR 방식으로 보안 강화



# 📢 After To-do
- [ ] CORS 설정
- [ ] refresh 토큰 DB 저장 구현
- [ ] 프론트 측 테스트
- [ ] 중복 코드 모듈화
- [ ] 이후 각각의 프로젝트에 맞게 구현하기